### PR TITLE
Migrate MobileUNet to TensorFlow 2.0

### DIFF
--- a/docs/issue_template.md
+++ b/docs/issue_template.md
@@ -24,12 +24,10 @@ Include any logs or source code that would be helpful to diagnose the problem. I
 
 ### FAQs
 
-- **Question:** I got an `InvalidArgumentError` saying that `Dimensions of inputs should match` **Answer:** See issue #17
+- **Question:** I got an `InvalidArgumentError` saying that `Dimensions of inputs should match` **Answer:** See [issue](https://github.com/GeorgeSeif/Semantic-Segmentation-Suite/issues/17).
 
-- **Question:** Can you upload pre-trained weights for these networks? **Answer:** See issue #57
+- **Question:** Can you upload pre-trained weights for these networks? **Answer:** See [issue](https://github.com/GeorgeSeif/Semantic-Segmentation-Suite/issues/57).
 
 - **Question:** Do I need a GPU to train these models? **Answer:** Technically no, but I'd highly recommend it. I was able to train the models pretty well in about a day using a 1080Ti GPU. Training on CPU would take much longer than that.
-
-- **Question:** Will you be adding the FCN or U-Net models? **Answer:** No I won't be adding those simply because they're a few years old and state-of-the-art has moved past that.
 
 - **Question:** I got an invalid argument error when using the InceptionV4 model. Am I doing something wrong? **Answer:** No you're not! Due to the design of the InceptiveV4 model, when you end up upsampling you do some rounding which creates a shape mismatch. _This only happens when you end up having to use the `end_points['pool5']`_. See the code for some of the models if you want to check whether the model will use `end_points['pool5']`.

--- a/models/MobileUNet.py
+++ b/models/MobileUNet.py
@@ -1,16 +1,15 @@
-import os,time,cv2
 import tensorflow as tf
 from tensorflow.keras.layers import Conv2D, BatchNormalization, ReLU, SeparableConv2D, Conv2DTranspose, MaxPool2D
 
 class ConvBlock(tf.keras.layers.Layer):
 	"""
 	Builds the conv block for MobileNets
-	Apply successivly a 2D convolution, BatchNormalization relu
+	Apply successivly a 2D convolution, BatchNormalization ReLU
 	"""
 	# Skip pointwise by setting num_outputs=Non
-	def __init__(self, n_filters, kernel_size=[3, 3]):
+	def __init__(self, n_filters, kernel_size=[1, 1]):
 		super(ConvBlock, self).__init__()
-		self.conv2d = Conv2D(n_filters, kernel_size=[1, 1], padding='same', activation=None)
+		self.conv2d = Conv2D(n_filters, kernel_size=kernel_size, padding='same', activation=None)
 		self.batchnorm = BatchNormalization(fused=True)
 		self.relu = ReLU()
 
@@ -19,28 +18,31 @@ class ConvBlock(tf.keras.layers.Layer):
 		x = self.batchnorm(x)
 		x = self.relu(x)
 		return x
+
 
 class DepthwiseSeparableConvBlock(tf.keras.layers.Layer):
 	"""
 	Builds the Depthwise Separable conv block for MobileNets
-	Apply successivly a 2D separable convolution, BatchNormalization relu, conv, BatchNormalization, relu
+	Apply successivly a 2D separable convolution, BatchNormalization ReLU, conv, BatchNormalization, ReLU
 	"""
 	# Skip pointwise by setting num_outputs=None
 	def __init__(self, n_filters, kernel_size=[3, 3]):
 		super(DepthwiseSeparableConvBlock, self).__init__()
-		self.separableconv2d = SeparableConv2D(n_filters, depth_multiplier=1, kernel_size=[3, 3], padding='same', activation=None)
-		self.batchnorm = BatchNormalization(fused=True)
+		self.separableconv2d = SeparableConv2D(n_filters, depth_multiplier=1, kernel_size=kernel_size, padding='same', activation=None)
+		self.batchnorm1 = BatchNormalization(fused=True)
 		self.relu = ReLU()
 		self.conv2d = Conv2D(n_filters, kernel_size=[1, 1], padding='same', activation=None)
+		self.batchnorm2 = BatchNormalization(fused=True)
 
 	def call(self, x):
 		x = self.separableconv2d(x)
-		x = self.batchnorm(x)
+		x = self.batchnorm1(x)
 		x = self.relu(x)
 		x = self.conv2d(x)
-		x = self.batchnorm(x)
+		x = self.batchnorm2(x)
 		x = self.relu(x)
 		return x
+
 
 class ConvTransposeBlock(tf.keras.layers.Layer):
 	"""
@@ -49,7 +51,7 @@ class ConvTransposeBlock(tf.keras.layers.Layer):
 	"""
 	def __init__(self, n_filters, kernel_size=[3, 3]):
 		super(ConvTransposeBlock, self).__init__()
-		self.conv2dtranspose = Conv2DTranspose(n_filters, kernel_size=[3, 3], strides=[2, 2], padding='same', activation=None)
+		self.conv2dtranspose = Conv2DTranspose(n_filters, kernel_size=kernel_size, strides=[2, 2], padding='same', activation=None)
 		self.batchnorm = BatchNormalization()
 		self.relu = ReLU()
 
@@ -59,101 +61,99 @@ class ConvTransposeBlock(tf.keras.layers.Layer):
 		x = self.relu(x)
 		return x
 
-class ResidualBlock(tf.keras.layers.Layer):
-	"""
-	Builds the Depthwise Separable conv block for MobileNets
-	Apply successivly a 2D separable convolution, BatchNormalization relu, conv, BatchNormalization, relu
-	"""
-	# Skip pointwise by setting num_outputs=None
-	def __init__(self, n_filters, n, isTranspose):
-		super(ResidualBlock, self).__init__()
+
+class DownSamplingBlock(tf.keras.layers.Layer):
+	def __init__(self, n_filters, n):
+		super(DownSamplingBlock, self).__init__()
 		self.features = tf.keras.Sequential()
-		if isTranspose:
-			self.features.add(ConvTransposeBlock(n_filters))
-			for _ in range(n):
-				self.features.add(DepthwiseSeparableConvBlock(n_filters))
-		else:
-			for _ in range(n):
-				self.features.add(DepthwiseSeparableConvBlock(n_filters))
-			self.features.add(MaxPool2D((2, 2), strides=2))
+		for _ in range(n):
+			self.features.add(DepthwiseSeparableConvBlock(n_filters))
+		self.features.add(MaxPool2D((2, 2), strides=2))
 
 	def call(self, x):
 		return self.features(x)
 
 
-class build_mobile_unet(tf.keras.Model):
-	def __init__(self, preset_model, num_classes):
-		super(build_mobile_unet, self).__init__()
-		self.conv_block = ConvBlock(64)
-		self.downsampling_block1 = ResidualBlock(64, 1, False)
-		self.downsampling_block2 = ResidualBlock(128, 2, False)
-		self.downsampling_block3 = ResidualBlock(256, 3, False)
-		self.downsampling_block4 = ResidualBlock(512, 3, False)
-		self.downsampling_block5 = ResidualBlock(512, 3, False)
-		self.upsampling_block1 = ResidualBlock(512, 3, True)
-		self.upsampling_block2 = ResidualBlock(512, 2, True)
-		self.upsampling_block3 = ResidualBlock(256, 2, True)
-		self.upsampling_block4 = ResidualBlock(128, 1, True)
-		self.upsampling_block5 = ResidualBlock(64, 2, True)
-		
-		self.depthwise_separable_conv_block_256 = DepthwiseSeparableConvBlock(256)
-		self.depthwise_separable_conv_block_128 = DepthwiseSeparableConvBlock(128)
-		self.depthwise_separable_conv_block_64 = DepthwiseSeparableConvBlock(64)
-		self.fc = Conv2D(num_classes, kernel_size=[1, 1], padding='same', activation=None)
-		self.has_skip = False
+class UpSamplingBlock(tf.keras.layers.Layer):
+	def __init__(self, n_filters, n, is_skip, out_depthwise_ch):
+		super(UpSamplingBlock, self).__init__()
+		self.is_skip = is_skip
+		self.features = tf.keras.Sequential()
+		self.features.add(ConvTransposeBlock(n_filters))
+		for _ in range(n):
+			self.features.add(DepthwiseSeparableConvBlock(n_filters))
+		self.features.add(DepthwiseSeparableConvBlock(out_depthwise_ch))
 
-		if preset_model == "MobileUNet":
-			self.has_skip = False
-		elif preset_model == "MobileUNet-Skip":
-			self.has_skip = True
-		else:
-			raise ValueError("Unsupported MobileUNet model '%s'. This function only supports MobileUNet and MobileUNet-Skip" % (preset_model))
+	def call(self, x1, x2):
+		x = self.features(x1)
+		if self.is_skip:
+			diffY = x2.shape[1] - x.shape[1]
+			diffX = x2.shape[2] - x.shape[2]
+			x = tf.pad(x, tf.constant([[0, 0], [diffY, 0], [diffX, 0], [0, 0]]))
+			x = tf.add(x, x2)
+		return x
 
-	def call(self, inputs):
+
+class MobileUNet(tf.keras.Model):
+    def __init__(self, num_classes, preset_model="MobileUNet-Skip"):
+        super(MobileUNet, self).__init__()
+        if preset_model == "MobileUNet":
+            self.has_skip = False
+        elif preset_model == "MobileUNet-Skip":
+            self.has_skip = True
+        else:
+            raise ValueError("Unsupported MobileUNet model '%s'. This function only supports MobileUNet and MobileUNet-Skip" % (preset_model))
+
+        self.conv_block = ConvBlock(64)
+        self.downsampling_block1 = DownSamplingBlock(64, 1)
+        self.downsampling_block2 = DownSamplingBlock(128, 2)
+        self.downsampling_block3 = DownSamplingBlock(256, 3)
+        self.downsampling_block4 = DownSamplingBlock(512, 3)
+        self.downsampling_block5 = DownSamplingBlock(512, 3)
+        self.upsampling_block1 = UpSamplingBlock(512, 2, self.has_skip, out_depthwise_ch=512)
+        self.upsampling_block2 = UpSamplingBlock(512, 2, self.has_skip, out_depthwise_ch=256)
+        self.upsampling_block3 = UpSamplingBlock(256, 2, self.has_skip, out_depthwise_ch=128)
+        self.upsampling_block4 = UpSamplingBlock(128, 1, self.has_skip, out_depthwise_ch=64)
+        self.upsampling_block5 = UpSamplingBlock(64, 1, False, out_depthwise_ch=64)
+        self.fc = Conv2D(num_classes, kernel_size=[1, 1], padding='same', activation=None)
+
+    def call(self, inputs):
 		#####################
 		# Downsampling path #
 		#####################
-		net = self.conv_block(inputs)
-		net = self.downsampling_block1(net)
-		skip_1 = net
+        net = self.conv_block(inputs)
 
-		net = self.downsampling_block2(net)
-		skip_2 = net
-		
-		net = self.downsampling_block3(net)
-		skip_3 = net
-		
-		net = self.downsampling_block4(net)
-		skip_4 = net
-		
-		net = self.downsampling_block5(net)
-		
-		#####################
-		# Upsampling path #
-		#####################
-		net = self.upsampling_block1(net)
-		if self.has_skip:
-			net = tf.add(net, skip_4)
+        net = self.downsampling_block1(net)
+        skip_1 = net
 
-		net = self.upsampling_block2(net)
-		net = self.depthwise_separable_conv_block_256(net)
-		if self.has_skip:
-			net = tf.add(net, skip_3)
+        net = self.downsampling_block2(net)
+        skip_2 = net
 
-		net = self.upsampling_block3(net)
-		net = self.depthwise_separable_conv_block_128(net)
-		if self.has_skip:
-			net = tf.add(net, skip_2)
+        net = self.downsampling_block3(net)
+        skip_3 = net
 
-		net = self.upsampling_block4(net)
-		net = self.depthwise_separable_conv_block_64(net)
-		if self.has_skip:
-			net = tf.add(net, skip_1)
+        net = self.downsampling_block4(net)
+        skip_4 = net
 
-		net = self.upsampling_block5(net)
+        net = self.downsampling_block5(net)
+        #####################
+        #  Upsampling path  #
+        #####################
+        net = self.upsampling_block1(net, skip_4)
 
-		#####################
-		#      Softmax      #
-		#####################
-		net = self.fc(net)
-		return net
+        net = self.upsampling_block2(net, skip_3)
+
+        net = self.upsampling_block3(net, skip_2)
+
+        net = self.upsampling_block4(net, skip_1)
+
+        net = self.upsampling_block5(net, None)
+
+        diffY = inputs.shape[1] - net.shape[1]
+        diffX = inputs.shape[2] - net.shape[2]
+        net = tf.pad(net, tf.constant([[0, 0], [diffY, 0], [diffX, 0], [0, 0]]))
+        #####################
+        #      Softmax      #
+        #####################
+        net = self.fc(net)
+        return net

--- a/models/MobileUNet.py
+++ b/models/MobileUNet.py
@@ -1,120 +1,159 @@
 import os,time,cv2
 import tensorflow as tf
-import tensorflow.contrib.slim as slim
-import numpy as np
+from tensorflow.keras.layers import Conv2D, BatchNormalization, ReLU, SeparableConv2D, Conv2DTranspose, MaxPool2D
 
-def ConvBlock(inputs, n_filters, kernel_size=[3, 3]):
+class ConvBlock(tf.keras.layers.Layer):
 	"""
 	Builds the conv block for MobileNets
 	Apply successivly a 2D convolution, BatchNormalization relu
 	"""
 	# Skip pointwise by setting num_outputs=Non
-	net = slim.conv2d(inputs, n_filters, kernel_size=[1, 1], activation_fn=None)
-	net = slim.batch_norm(net, fused=True)
-	net = tf.nn.relu(net)
-	return net
+	def __init__(self, n_filters, kernel_size=[3, 3]):
+		super(ConvBlock, self).__init__()
+		self.conv2d = Conv2D(n_filters, kernel_size=[1, 1], padding='same', activation=None)
+		self.batchnorm = BatchNormalization(fused=True)
+		self.relu = ReLU()
 
-def DepthwiseSeparableConvBlock(inputs, n_filters, kernel_size=[3, 3]):
+	def call(self, x):
+		x = self.conv2d(x)
+		x = self.batchnorm(x)
+		x = self.relu(x)
+		return x
+
+class DepthwiseSeparableConvBlock(tf.keras.layers.Layer):
 	"""
 	Builds the Depthwise Separable conv block for MobileNets
 	Apply successivly a 2D separable convolution, BatchNormalization relu, conv, BatchNormalization, relu
 	"""
 	# Skip pointwise by setting num_outputs=None
-	net = slim.separable_convolution2d(inputs, num_outputs=None, depth_multiplier=1, kernel_size=[3, 3], activation_fn=None)
+	def __init__(self, n_filters, kernel_size=[3, 3]):
+		super(DepthwiseSeparableConvBlock, self).__init__()
+		self.separableconv2d = SeparableConv2D(n_filters, depth_multiplier=1, kernel_size=[3, 3], padding='same', activation=None)
+		self.batchnorm = BatchNormalization(fused=True)
+		self.relu = ReLU()
+		self.conv2d = Conv2D(n_filters, kernel_size=[1, 1], padding='same', activation=None)
 
-	net = slim.batch_norm(net, fused=True)
-	net = tf.nn.relu(net)
-	net = slim.conv2d(net, n_filters, kernel_size=[1, 1], activation_fn=None)
-	net = slim.batch_norm(net, fused=True)
-	net = tf.nn.relu(net)
-	return net
+	def call(self, x):
+		x = self.separableconv2d(x)
+		x = self.batchnorm(x)
+		x = self.relu(x)
+		x = self.conv2d(x)
+		x = self.batchnorm(x)
+		x = self.relu(x)
+		return x
 
-def conv_transpose_block(inputs, n_filters, kernel_size=[3, 3]):
+class ConvTransposeBlock(tf.keras.layers.Layer):
 	"""
 	Basic conv transpose block for Encoder-Decoder upsampling
 	Apply successivly Transposed Convolution, BatchNormalization, ReLU nonlinearity
 	"""
-	net = slim.conv2d_transpose(inputs, n_filters, kernel_size=[3, 3], stride=[2, 2], activation_fn=None)
-	net = tf.nn.relu(slim.batch_norm(net))
-	return net
+	def __init__(self, n_filters, kernel_size=[3, 3]):
+		super(ConvTransposeBlock, self).__init__()
+		self.conv2dtranspose = Conv2DTranspose(n_filters, kernel_size=[3, 3], strides=[2, 2], padding='same', activation=None)
+		self.batchnorm = BatchNormalization()
+		self.relu = ReLU()
 
-def build_mobile_unet(inputs, preset_model, num_classes):
+	def call(self, x):
+		x = self.conv2dtranspose(x)
+		x = self.batchnorm(x)
+		x = self.relu(x)
+		return x
 
-	has_skip = False
-	if preset_model == "MobileUNet":
-		has_skip = False
-	elif preset_model == "MobileUNet-Skip":
-		has_skip = True
-	else:
-		raise ValueError("Unsupported MobileUNet model '%s'. This function only supports MobileUNet and MobileUNet-Skip" % (preset_model))
+class ResidualBlock(tf.keras.layers.Layer):
+	"""
+	Builds the Depthwise Separable conv block for MobileNets
+	Apply successivly a 2D separable convolution, BatchNormalization relu, conv, BatchNormalization, relu
+	"""
+	# Skip pointwise by setting num_outputs=None
+	def __init__(self, n_filters, n, isTranspose):
+		super(ResidualBlock, self).__init__()
+		self.features = tf.keras.Sequential()
+		if isTranspose:
+			self.features.add(ConvTransposeBlock(n_filters))
+			for _ in range(n):
+				self.features.add(DepthwiseSeparableConvBlock(n_filters))
+		else:
+			for _ in range(n):
+				self.features.add(DepthwiseSeparableConvBlock(n_filters))
+			self.features.add(MaxPool2D((2, 2), strides=2))
 
-    #####################
-	# Downsampling path #
-	#####################
-	net = ConvBlock(inputs, 64)
-	net = DepthwiseSeparableConvBlock(net, 64)
-	net = slim.pool(net, [2, 2], stride=[2, 2], pooling_type='MAX')
-	skip_1 = net
-
-	net = DepthwiseSeparableConvBlock(net, 128)
-	net = DepthwiseSeparableConvBlock(net, 128)
-	net = slim.pool(net, [2, 2], stride=[2, 2], pooling_type='MAX')
-	skip_2 = net
-
-	net = DepthwiseSeparableConvBlock(net, 256)
-	net = DepthwiseSeparableConvBlock(net, 256)
-	net = DepthwiseSeparableConvBlock(net, 256)
-	net = slim.pool(net, [2, 2], stride=[2, 2], pooling_type='MAX')
-	skip_3 = net
-
-	net = DepthwiseSeparableConvBlock(net, 512)
-	net = DepthwiseSeparableConvBlock(net, 512)
-	net = DepthwiseSeparableConvBlock(net, 512)
-	net = slim.pool(net, [2, 2], stride=[2, 2], pooling_type='MAX')
-	skip_4 = net
-
-	net = DepthwiseSeparableConvBlock(net, 512)
-	net = DepthwiseSeparableConvBlock(net, 512)
-	net = DepthwiseSeparableConvBlock(net, 512)
-	net = slim.pool(net, [2, 2], stride=[2, 2], pooling_type='MAX')
+	def call(self, x):
+		return self.features(x)
 
 
-	#####################
-	# Upsampling path #
-	#####################
-	net = conv_transpose_block(net, 512)
-	net = DepthwiseSeparableConvBlock(net, 512)
-	net = DepthwiseSeparableConvBlock(net, 512)
-	net = DepthwiseSeparableConvBlock(net, 512)
-	if has_skip:
-		net = tf.add(net, skip_4)
+class build_mobile_unet(tf.keras.Model):
+	def __init__(self, preset_model, num_classes):
+		super(build_mobile_unet, self).__init__()
+		self.conv_block = ConvBlock(64)
+		self.downsampling_block1 = ResidualBlock(64, 1, False)
+		self.downsampling_block2 = ResidualBlock(128, 2, False)
+		self.downsampling_block3 = ResidualBlock(256, 3, False)
+		self.downsampling_block4 = ResidualBlock(512, 3, False)
+		self.downsampling_block5 = ResidualBlock(512, 3, False)
+		self.upsampling_block1 = ResidualBlock(512, 3, True)
+		self.upsampling_block2 = ResidualBlock(512, 2, True)
+		self.upsampling_block3 = ResidualBlock(256, 2, True)
+		self.upsampling_block4 = ResidualBlock(128, 1, True)
+		self.upsampling_block5 = ResidualBlock(64, 2, True)
+		
+		self.depthwise_separable_conv_block_256 = DepthwiseSeparableConvBlock(256)
+		self.depthwise_separable_conv_block_128 = DepthwiseSeparableConvBlock(128)
+		self.depthwise_separable_conv_block_64 = DepthwiseSeparableConvBlock(64)
+		self.fc = Conv2D(num_classes, kernel_size=[1, 1], padding='same', activation=None)
+		self.has_skip = False
 
-	net = conv_transpose_block(net, 512)
-	net = DepthwiseSeparableConvBlock(net, 512)
-	net = DepthwiseSeparableConvBlock(net, 512)
-	net = DepthwiseSeparableConvBlock(net, 256)
-	if has_skip:
-		net = tf.add(net, skip_3)
+		if preset_model == "MobileUNet":
+			self.has_skip = False
+		elif preset_model == "MobileUNet-Skip":
+			self.has_skip = True
+		else:
+			raise ValueError("Unsupported MobileUNet model '%s'. This function only supports MobileUNet and MobileUNet-Skip" % (preset_model))
 
-	net = conv_transpose_block(net, 256)
-	net = DepthwiseSeparableConvBlock(net, 256)
-	net = DepthwiseSeparableConvBlock(net, 256)
-	net = DepthwiseSeparableConvBlock(net, 128)
-	if has_skip:
-		net = tf.add(net, skip_2)
+	def call(self, inputs):
+		#####################
+		# Downsampling path #
+		#####################
+		net = self.conv_block(inputs)
+		net = self.downsampling_block1(net)
+		skip_1 = net
 
-	net = conv_transpose_block(net, 128)
-	net = DepthwiseSeparableConvBlock(net, 128)
-	net = DepthwiseSeparableConvBlock(net, 64)
-	if has_skip:
-		net = tf.add(net, skip_1)
+		net = self.downsampling_block2(net)
+		skip_2 = net
+		
+		net = self.downsampling_block3(net)
+		skip_3 = net
+		
+		net = self.downsampling_block4(net)
+		skip_4 = net
+		
+		net = self.downsampling_block5(net)
+		
+		#####################
+		# Upsampling path #
+		#####################
+		net = self.upsampling_block1(net)
+		if self.has_skip:
+			net = tf.add(net, skip_4)
 
-	net = conv_transpose_block(net, 64)
-	net = DepthwiseSeparableConvBlock(net, 64)
-	net = DepthwiseSeparableConvBlock(net, 64)
+		net = self.upsampling_block2(net)
+		net = self.depthwise_separable_conv_block_256(net)
+		if self.has_skip:
+			net = tf.add(net, skip_3)
 
-	#####################
-	#      Softmax      #
-	#####################
-	net = slim.conv2d(net, num_classes, [1, 1], activation_fn=None, scope='logits')
-	return net
+		net = self.upsampling_block3(net)
+		net = self.depthwise_separable_conv_block_128(net)
+		if self.has_skip:
+			net = tf.add(net, skip_2)
+
+		net = self.upsampling_block4(net)
+		net = self.depthwise_separable_conv_block_64(net)
+		if self.has_skip:
+			net = tf.add(net, skip_1)
+
+		net = self.upsampling_block5(net)
+
+		#####################
+		#      Softmax      #
+		#####################
+		net = self.fc(net)
+		return net

--- a/tests/models/test_MobileUNet.py
+++ b/tests/models/test_MobileUNet.py
@@ -1,0 +1,291 @@
+import unittest
+import numpy as np
+import tensorflow as tf
+from MobileUNet import MobileUNet, ConvBlock, DepthwiseSeparableConvBlock, ConvTransposeBlock, DownSamplingBlock, UpSamplingBlock
+
+class TestStringMethods(unittest.TestCase):
+
+    def get_random_data(self, shape):
+        return tf.random.uniform([*shape])
+
+    def network(self, input_shape, num_classes):
+        output_shape = input_shape[:-1] + (num_classes,)
+        inputs = self.get_random_data(input_shape)
+        net = MobileUNet(num_classes, "MobileUNet")
+
+        output = net(inputs)
+        return output, output_shape
+
+    def network_skip(self, input_shape, num_classes):
+        output_shape = input_shape[:-1] + (num_classes,)
+        inputs = self.get_random_data(input_shape)
+        net = MobileUNet(num_classes)
+
+        output = net(inputs)
+        return output, output_shape
+
+    def test_ConvBlock(self):
+        num_classes = 16
+        input_shape = (1,32,32,3)
+        output_shape = input_shape[:-1] + (num_classes,)
+
+        inputs = self.get_random_data(input_shape)
+        net = ConvBlock(num_classes)
+
+        output = net(inputs)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_DepthwiseSeparableConvBlock(self):
+        num_classes = 16
+        input_shape = (1,32,32,3)
+        output_shape = input_shape[:-1] + (num_classes,)
+
+        inputs = self.get_random_data(input_shape)
+        net = DepthwiseSeparableConvBlock(num_classes)
+
+        output = net(inputs)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_ConvTransposeBlock(self):
+        num_classes = 16
+        input_shape = (1,32,32,3)
+        output_shape = (input_shape[0], input_shape[1]*2, input_shape[2]*2) + (num_classes,)
+
+        inputs = self.get_random_data(input_shape)
+        net = ConvTransposeBlock(num_classes)
+
+        output = net(inputs)
+        self.assertEqual(output_shape, output.shape)    
+
+    def test_DownSamplingBlock(self):
+        num_classes = 16
+        n = 3
+        input_shape = (1,32,32,3)
+        output_shape = (input_shape[0], int(input_shape[1]/2), int(input_shape[2]/2)) + (num_classes,)
+
+        inputs = self.get_random_data(input_shape)
+        net = DownSamplingBlock(num_classes, n)
+
+        output = net(inputs)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_UpSamplingBlock_skip(self):
+        num_classes = 16
+        n = 3
+        input_shape = (1,32,32,3)
+        skip_shape = (1,64,64,num_classes)
+        output_shape = skip_shape[:-1] + (num_classes,)
+
+        inputs = self.get_random_data(input_shape)
+        skips = self.get_random_data(skip_shape)
+        net = UpSamplingBlock(num_classes, n, is_skip=True, out_depthwise_ch=num_classes)
+
+        output = net(inputs, skips)
+        self.assertEqual(output_shape, output.shape) 
+
+    def test_UpSamplingBlock(self):
+        num_classes = 16
+        n = 3
+        input_shape = (1,32,32,3)
+        output_shape = (input_shape[0], input_shape[1]*2, input_shape[2]*2) + (num_classes,)
+
+        inputs = self.get_random_data(input_shape)
+        net = UpSamplingBlock(num_classes, n, is_skip=False, out_depthwise_ch=num_classes)
+
+        output = net(inputs, None)
+        self.assertEqual(output_shape, output.shape) 
+    
+    def test_UpSamplingBlock_padding(self):
+        num_classes = 4
+        n = 3
+
+        input_shape1 = (1,32,32,num_classes)
+        skip_shape1 = (1,64,65,num_classes)
+        output_shape1 = skip_shape1
+
+        input_shape2 = (1,31,31,num_classes)
+        skip_shape2 = (1,63,62,num_classes)
+        output_shape2 = skip_shape2
+
+        input_shape3 = (1,1,1,num_classes)
+        skip_shape3 = (1,2,2,num_classes)
+        output_shape3 = skip_shape3
+
+        net1 = UpSamplingBlock(num_classes, n, is_skip=True, out_depthwise_ch=num_classes)
+        net2 = UpSamplingBlock(num_classes, n, is_skip=True, out_depthwise_ch=num_classes)
+        net3 = UpSamplingBlock(num_classes, n, is_skip=True, out_depthwise_ch=num_classes)
+
+        inputs1 = self.get_random_data(input_shape1)
+        inputs2 = self.get_random_data(input_shape2)
+        inputs3 = self.get_random_data(input_shape3)
+
+        skips1 = self.get_random_data(skip_shape1)
+        skips2 = self.get_random_data(skip_shape2)
+        skips3 = self.get_random_data(skip_shape3)
+
+        output1 = net1(inputs1, skips1)
+        output2 = net2(inputs2, skips2)
+        output3 = net3(inputs3, skips3)
+
+        self.assertEqual(output_shape1, output1.shape)
+        self.assertEqual(output_shape2, output2.shape)
+        self.assertEqual(output_shape3, output3.shape)
+
+    def test_output_type_skip(self):
+        num_classes = 16
+        input_shape = (1,32,32,3)
+        output_shape = input_shape[:-1] + (num_classes,)
+        inputs = self.get_random_data(input_shape)
+        net = MobileUNet(num_classes)
+
+        output = net(inputs)
+
+        self.assertIsInstance(output, tf.Tensor)
+        self.assertIs(output.dtype, tf.float32)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_nomal_input_skip(self):
+        num_classes = 32
+        input_shape = (1,512,512,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_multi_batch_skip(self):
+        num_classes = 32
+        input_shape = (3,64,64,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_variable_input_skip(self):
+        num_classes = 32
+        input_shape = (1,71,61,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 32
+        input_shape = (1,117,41,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 32
+        input_shape = (1,37,129,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_small_input_skip(self):
+        num_classes = 32
+        input_shape = (1,15,15,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 32
+        input_shape = (1,15,512,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 32
+        input_shape = (1,512,15,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 32
+        input_shape = (1,1,1,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_variable_num_classes_skip(self):
+        num_classes = 16
+        input_shape = (1,512,512,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 7
+        input_shape = (1,512,512,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 2
+        input_shape = (1,512,512,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_output_type(self):
+        num_classes = 16
+        input_shape = (1,32,32,3)
+        output_shape = input_shape[:-1] + (num_classes,)
+        inputs = self.get_random_data(input_shape)
+        net = MobileUNet(num_classes, "MobileUNet")
+
+        output = net(inputs)
+
+        self.assertIsInstance(output, tf.Tensor)
+        self.assertIs(output.dtype, tf.float32)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_nomal_input(self):
+        num_classes = 32
+        input_shape = (1,512,512,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_multi_batch(self):
+        num_classes = 32
+        input_shape = (3,64,64,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_variable_input(self):
+        num_classes = 32
+        input_shape = (1,71,61,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 32
+        input_shape = (1,117,41,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 32
+        input_shape = (1,37,129,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_small_input(self):
+        num_classes = 32
+        input_shape = (1,15,15,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 32
+        input_shape = (1,15,512,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 32
+        input_shape = (1,512,15,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 32
+        input_shape = (1,1,1,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_variable_num_classes(self):
+        num_classes = 16
+        input_shape = (1,512,512,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 7
+        input_shape = (1,512,512,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 2
+        input_shape = (1,512,512,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
ISSUE: #1
Upgrade to tensorflow 2.0 MobileUNet

Change models defined using def to models using `keras.Layer` and `keras.Model`
Change modules defined using `tensorflow.contrib.slim` to modules using `tensorflow.keras.layers`
Add `UpSamplingBlock` and `DownSamplingBlock`
Make it possible to accept inputs of various sizes by padding