### PR TITLE
Solve various input size problem in U-Net

### DIFF
--- a/models/MobileUNet.py
+++ b/models/MobileUNet.py
@@ -1,120 +1,162 @@
-import os,time,cv2
 import tensorflow as tf
-import tensorflow.contrib.slim as slim
-import numpy as np
+from tensorflow.keras.layers import Conv2D, BatchNormalization, ReLU, SeparableConv2D, Conv2DTranspose, MaxPool2D
 
-def ConvBlock(inputs, n_filters, kernel_size=[3, 3]):
+class ConvBlock(tf.keras.layers.Layer):
 	"""
 	Builds the conv block for MobileNets
-	Apply successivly a 2D convolution, BatchNormalization relu
+	Apply successivly a 2D convolution, BatchNormalization ReLU
 	"""
 	# Skip pointwise by setting num_outputs=Non
-	net = slim.conv2d(inputs, n_filters, kernel_size=[1, 1], activation_fn=None)
-	net = slim.batch_norm(net, fused=True)
-	net = tf.nn.relu(net)
-	return net
+	def __init__(self, n_filters, kernel_size=[1, 1]):
+		super(ConvBlock, self).__init__()
+		self.conv2d = Conv2D(n_filters, kernel_size=kernel_size, padding='same', activation=None)
+		self.batchnorm = BatchNormalization(fused=True)
+		self.relu = ReLU()
 
-def DepthwiseSeparableConvBlock(inputs, n_filters, kernel_size=[3, 3]):
+	def call(self, x):
+		x = self.conv2d(x)
+		x = self.batchnorm(x)
+		x = self.relu(x)
+		return x
+
+
+class DepthwiseSeparableConvBlock(tf.keras.layers.Layer):
 	"""
 	Builds the Depthwise Separable conv block for MobileNets
-	Apply successivly a 2D separable convolution, BatchNormalization relu, conv, BatchNormalization, relu
+	Apply successivly a 2D separable convolution, BatchNormalization ReLU, conv, BatchNormalization, ReLU
 	"""
 	# Skip pointwise by setting num_outputs=None
-	net = slim.separable_convolution2d(inputs, num_outputs=None, depth_multiplier=1, kernel_size=[3, 3], activation_fn=None)
+	def __init__(self, n_filters, kernel_size=[3, 3]):
+		super(DepthwiseSeparableConvBlock, self).__init__()
+		self.separableconv2d = SeparableConv2D(n_filters, depth_multiplier=1, kernel_size=kernel_size, padding='same', activation=None)
+		self.batchnorm1 = BatchNormalization(fused=True)
+		self.relu = ReLU()
+		self.conv2d = Conv2D(n_filters, kernel_size=[1, 1], padding='same', activation=None)
+		self.batchnorm2 = BatchNormalization(fused=True)
 
-	net = slim.batch_norm(net, fused=True)
-	net = tf.nn.relu(net)
-	net = slim.conv2d(net, n_filters, kernel_size=[1, 1], activation_fn=None)
-	net = slim.batch_norm(net, fused=True)
-	net = tf.nn.relu(net)
-	return net
+	def call(self, x):
+		x = self.separableconv2d(x)
+		x = self.batchnorm1(x)
+		x = self.relu(x)
+		x = self.conv2d(x)
+		x = self.batchnorm2(x)
+		x = self.relu(x)
+		return x
 
-def conv_transpose_block(inputs, n_filters, kernel_size=[3, 3]):
+
+class ConvTransposeBlock(tf.keras.layers.Layer):
 	"""
 	Basic conv transpose block for Encoder-Decoder upsampling
 	Apply successivly Transposed Convolution, BatchNormalization, ReLU nonlinearity
 	"""
-	net = slim.conv2d_transpose(inputs, n_filters, kernel_size=[3, 3], stride=[2, 2], activation_fn=None)
-	net = tf.nn.relu(slim.batch_norm(net))
-	return net
+	def __init__(self, n_filters, kernel_size=[3, 3]):
+		super(ConvTransposeBlock, self).__init__()
+		self.conv2dtranspose = Conv2DTranspose(n_filters, kernel_size=kernel_size, strides=[2, 2], padding='same', activation=None)
+		self.batchnorm = BatchNormalization()
+		self.relu = ReLU()
 
-def build_mobile_unet(inputs, preset_model, num_classes):
-
-	has_skip = False
-	if preset_model == "MobileUNet":
-		has_skip = False
-	elif preset_model == "MobileUNet-Skip":
-		has_skip = True
-	else:
-		raise ValueError("Unsupported MobileUNet model '%s'. This function only supports MobileUNet and MobileUNet-Skip" % (preset_model))
-
-    #####################
-	# Downsampling path #
-	#####################
-	net = ConvBlock(inputs, 64)
-	net = DepthwiseSeparableConvBlock(net, 64)
-	net = slim.pool(net, [2, 2], stride=[2, 2], pooling_type='MAX')
-	skip_1 = net
-
-	net = DepthwiseSeparableConvBlock(net, 128)
-	net = DepthwiseSeparableConvBlock(net, 128)
-	net = slim.pool(net, [2, 2], stride=[2, 2], pooling_type='MAX')
-	skip_2 = net
-
-	net = DepthwiseSeparableConvBlock(net, 256)
-	net = DepthwiseSeparableConvBlock(net, 256)
-	net = DepthwiseSeparableConvBlock(net, 256)
-	net = slim.pool(net, [2, 2], stride=[2, 2], pooling_type='MAX')
-	skip_3 = net
-
-	net = DepthwiseSeparableConvBlock(net, 512)
-	net = DepthwiseSeparableConvBlock(net, 512)
-	net = DepthwiseSeparableConvBlock(net, 512)
-	net = slim.pool(net, [2, 2], stride=[2, 2], pooling_type='MAX')
-	skip_4 = net
-
-	net = DepthwiseSeparableConvBlock(net, 512)
-	net = DepthwiseSeparableConvBlock(net, 512)
-	net = DepthwiseSeparableConvBlock(net, 512)
-	net = slim.pool(net, [2, 2], stride=[2, 2], pooling_type='MAX')
+	def call(self, x):
+		x = self.conv2dtranspose(x)
+		x = self.batchnorm(x)
+		x = self.relu(x)
+		return x
 
 
-	#####################
-	# Upsampling path #
-	#####################
-	net = conv_transpose_block(net, 512)
-	net = DepthwiseSeparableConvBlock(net, 512)
-	net = DepthwiseSeparableConvBlock(net, 512)
-	net = DepthwiseSeparableConvBlock(net, 512)
-	if has_skip:
-		net = tf.add(net, skip_4)
+class DownSamplingBlock(tf.keras.layers.Layer):
+	def __init__(self, n_filters, n):
+		super(DownSamplingBlock, self).__init__()
+		self.features = []
+		for _ in range(n):
+			self.features.append(DepthwiseSeparableConvBlock(n_filters))
+		self.features.append(MaxPool2D((2, 2), strides=2))
 
-	net = conv_transpose_block(net, 512)
-	net = DepthwiseSeparableConvBlock(net, 512)
-	net = DepthwiseSeparableConvBlock(net, 512)
-	net = DepthwiseSeparableConvBlock(net, 256)
-	if has_skip:
-		net = tf.add(net, skip_3)
+	def call(self, x):
+		for layer in self.features:
+			x = layer(x)
+		return x
 
-	net = conv_transpose_block(net, 256)
-	net = DepthwiseSeparableConvBlock(net, 256)
-	net = DepthwiseSeparableConvBlock(net, 256)
-	net = DepthwiseSeparableConvBlock(net, 128)
-	if has_skip:
-		net = tf.add(net, skip_2)
 
-	net = conv_transpose_block(net, 128)
-	net = DepthwiseSeparableConvBlock(net, 128)
-	net = DepthwiseSeparableConvBlock(net, 64)
-	if has_skip:
-		net = tf.add(net, skip_1)
+class UpSamplingBlock(tf.keras.layers.Layer):
+	def __init__(self, n_filters, n, is_skip, out_depthwise_ch):
+		super(UpSamplingBlock, self).__init__()
+		self.is_skip = is_skip
+		self.features = []
+		self.features.append(ConvTransposeBlock(n_filters))
+		for _ in range(n):
+			self.features.append(DepthwiseSeparableConvBlock(n_filters))
+		self.features.append(DepthwiseSeparableConvBlock(out_depthwise_ch))
 
-	net = conv_transpose_block(net, 64)
-	net = DepthwiseSeparableConvBlock(net, 64)
-	net = DepthwiseSeparableConvBlock(net, 64)
+	def call(self, x1, x2):
+		for layer in self.features:
+			x1 = layer(x1)
+		if self.is_skip:
+			diffY = x2.shape[1] - x1.shape[1]
+			diffX = x2.shape[2] - x1.shape[2]
+			x1 = tf.pad(x1, tf.constant([[0, 0], [diffY, 0], [diffX, 0], [0, 0]]))
+			x1 = tf.add(x1, x2)
+		return x1
 
-	#####################
-	#      Softmax      #
-	#####################
-	net = slim.conv2d(net, num_classes, [1, 1], activation_fn=None, scope='logits')
-	return net
+
+class MobileUNet(tf.keras.Model):
+    def __init__(self, num_classes, preset_model="MobileUNet-Skip"):
+        super(MobileUNet, self).__init__()
+        if preset_model == "MobileUNet":
+            self.has_skip = False
+        elif preset_model == "MobileUNet-Skip":
+            self.has_skip = True
+        else:
+            raise ValueError("Unsupported MobileUNet model '%s'. This function only supports MobileUNet and MobileUNet-Skip" % (preset_model))
+
+        self.conv_block = ConvBlock(64)
+        self.downsampling_block1 = DownSamplingBlock(64, 1)
+        self.downsampling_block2 = DownSamplingBlock(128, 2)
+        self.downsampling_block3 = DownSamplingBlock(256, 3)
+        self.downsampling_block4 = DownSamplingBlock(512, 3)
+        self.downsampling_block5 = DownSamplingBlock(512, 3)
+        self.upsampling_block1 = UpSamplingBlock(512, 2, self.has_skip, out_depthwise_ch=512)
+        self.upsampling_block2 = UpSamplingBlock(512, 2, self.has_skip, out_depthwise_ch=256)
+        self.upsampling_block3 = UpSamplingBlock(256, 2, self.has_skip, out_depthwise_ch=128)
+        self.upsampling_block4 = UpSamplingBlock(128, 1, self.has_skip, out_depthwise_ch=64)
+        self.upsampling_block5 = UpSamplingBlock(64, 1, False, out_depthwise_ch=64)
+        self.fc = Conv2D(num_classes, kernel_size=[1, 1], padding='same', activation=None)
+
+    def call(self, inputs):
+		#####################
+		# Downsampling path #
+		#####################
+        net = self.conv_block(inputs)
+
+        net = self.downsampling_block1(net)
+        skip_1 = net
+
+        net = self.downsampling_block2(net)
+        skip_2 = net
+
+        net = self.downsampling_block3(net)
+        skip_3 = net
+
+        net = self.downsampling_block4(net)
+        skip_4 = net
+
+        net = self.downsampling_block5(net)
+        #####################
+        #  Upsampling path  #
+        #####################
+        net = self.upsampling_block1(net, skip_4)
+
+        net = self.upsampling_block2(net, skip_3)
+
+        net = self.upsampling_block3(net, skip_2)
+
+        net = self.upsampling_block4(net, skip_1)
+
+        net = self.upsampling_block5(net, None)
+
+        diffY = inputs.shape[1] - net.shape[1]
+        diffX = inputs.shape[2] - net.shape[2]
+        net = tf.pad(net, tf.constant([[0, 0], [diffY, 0], [diffX, 0], [0, 0]]))
+        #####################
+        #      Softmax      #
+        #####################
+        net = self.fc(net)
+        return net

--- a/models/MobileUNet.py
+++ b/models/MobileUNet.py
@@ -121,9 +121,9 @@ class MobileUNet(tf.keras.Model):
         self.fc = Conv2D(num_classes, kernel_size=[1, 1], padding='same', activation=None)
 
     def call(self, inputs):
-		#####################
-		# Downsampling path #
-		#####################
+        #####################
+        # Downsampling path #
+        #####################
         net = self.conv_block(inputs)
 
         net = self.downsampling_block1(net)
@@ -139,6 +139,7 @@ class MobileUNet(tf.keras.Model):
         skip_4 = net
 
         net = self.downsampling_block5(net)
+
         #####################
         #  Upsampling path  #
         #####################
@@ -155,8 +156,10 @@ class MobileUNet(tf.keras.Model):
         diffY = inputs.shape[1] - net.shape[1]
         diffX = inputs.shape[2] - net.shape[2]
         net = tf.pad(net, tf.constant([[0, 0], [diffY, 0], [diffX, 0], [0, 0]]))
+
         #####################
         #      Softmax      #
         #####################
         net = self.fc(net)
+        
         return net

--- a/models/UNet.py
+++ b/models/UNet.py
@@ -16,16 +16,16 @@ def ConvBlock(inputs, n_filters, kernel_size=[3, 3]):
     net = batch_norm(net)
     return net
 
-def conv_transpose_block(inputs, n_filters, kernel_size=[3, 3], output_shape = None):
+def conv_transpose_block(inputs, n_filters, kernel_size=[3, 3], strides=[2, 2], output_shape=None):
     """
     Basic conv transpose block for Encoder-Decoder upsampling
     Apply successivly Transposed Convolution, BatchNormalization, ReLU
     """
     if output_shape is None:
-        output_padding = [1,1]
+        output_padding = [strides[0]-1,strides[1]-1]
     else:
-        output_padding = [(output_shape[1]+1)%2, (output_shape[2]+1)%2]
-    conv2d_transpose_layer = tf.keras.layers.Conv2DTranspose(n_filters, kernel_size=kernel_size, strides=[2, 2], output_padding=output_padding, padding="same")
+        output_padding = [(output_shape[1]+strides[0]-1)%strides[0], (output_shape[2]+strides[1]-1)%strides[1]]
+    conv2d_transpose_layer = tf.keras.layers.Conv2DTranspose(n_filters, kernel_size=kernel_size, strides=strides, output_padding=output_padding, padding="same")
     batch_norm = tf.keras.layers.BatchNormalization(axis = -1, fused=True)
 
     net = conv2d_transpose_layer(inputs)
@@ -38,8 +38,10 @@ def build_unet(inputs, preset_model, num_classes):
     #####################
     # Downsampling path #
     #####################
+
+    strides = (2, 2)
     
-    max_pooling = tf.keras.layers.MaxPool2D(pool_size = (2,2), strides = (2,2), padding = "same")
+    max_pooling = tf.keras.layers.MaxPool2D(pool_size=(2,2), strides=strides, padding="same")
     
     net = ConvBlock(inputs, 64)
     net = ConvBlock(net, 64)
@@ -68,25 +70,26 @@ def build_unet(inputs, preset_model, num_classes):
     # Upsampling path  #
     ####################
 
-    net = conv_transpose_block(net, 512, output_shape = skip_4.shape)
+    net = conv_transpose_block(net, 512, strides=strides, output_shape=skip_4.shape)
     net = tf.add(net, skip_4)
     net = ConvBlock(net, 512)
     net = ConvBlock(net, 512)
 
-    net = conv_transpose_block(net, 256, output_shape = skip_3.shape)
+    net = conv_transpose_block(net, 256, strides=strides, output_shape=skip_3.shape)
     net = tf.add(net, skip_3)
     net = ConvBlock(net, 256)
     net = ConvBlock(net, 256)
 
-    net = conv_transpose_block(net, 128, output_shape = skip_2.shape)
+    net = conv_transpose_block(net, 128, strides=strides, output_shape=skip_2.shape)
     net = tf.add(net, skip_2)
     net = ConvBlock(net, 128)
     net = ConvBlock(net, 128)
 
-    net = conv_transpose_block(net, 64, output_shape = skip_1.shape)
+    net = conv_transpose_block(net, 64, strides=strides, output_shape=skip_1.shape)
     net = tf.add(net, skip_1)
     net = ConvBlock(net, 64)
     net = ConvBlock(net, 64)
+
     #####################
     #      Softmax      #
     #####################

--- a/tests/models/test_MobileUNet.py
+++ b/tests/models/test_MobileUNet.py
@@ -1,0 +1,291 @@
+import unittest
+import numpy as np
+import tensorflow as tf
+from MobileUNet import MobileUNet, ConvBlock, DepthwiseSeparableConvBlock, ConvTransposeBlock, DownSamplingBlock, UpSamplingBlock
+
+class TestStringMethods(unittest.TestCase):
+
+    def get_random_data(self, shape):
+        return tf.random.uniform([*shape])
+
+    def network(self, input_shape, num_classes):
+        output_shape = input_shape[:-1] + (num_classes,)
+        inputs = self.get_random_data(input_shape)
+        net = MobileUNet(num_classes, "MobileUNet")
+
+        output = net(inputs)
+        return output, output_shape
+
+    def network_skip(self, input_shape, num_classes):
+        output_shape = input_shape[:-1] + (num_classes,)
+        inputs = self.get_random_data(input_shape)
+        net = MobileUNet(num_classes)
+
+        output = net(inputs)
+        return output, output_shape
+
+    def test_ConvBlock(self):
+        num_classes = 16
+        input_shape = (1,32,32,3)
+        output_shape = input_shape[:-1] + (num_classes,)
+
+        inputs = self.get_random_data(input_shape)
+        net = ConvBlock(num_classes)
+
+        output = net(inputs)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_DepthwiseSeparableConvBlock(self):
+        num_classes = 16
+        input_shape = (1,32,32,3)
+        output_shape = input_shape[:-1] + (num_classes,)
+
+        inputs = self.get_random_data(input_shape)
+        net = DepthwiseSeparableConvBlock(num_classes)
+
+        output = net(inputs)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_ConvTransposeBlock(self):
+        num_classes = 16
+        input_shape = (1,32,32,3)
+        output_shape = (input_shape[0], input_shape[1]*2, input_shape[2]*2) + (num_classes,)
+
+        inputs = self.get_random_data(input_shape)
+        net = ConvTransposeBlock(num_classes)
+
+        output = net(inputs)
+        self.assertEqual(output_shape, output.shape)    
+
+    def test_DownSamplingBlock(self):
+        num_classes = 16
+        n = 3
+        input_shape = (1,32,32,3)
+        output_shape = (input_shape[0], int(input_shape[1]/2), int(input_shape[2]/2)) + (num_classes,)
+
+        inputs = self.get_random_data(input_shape)
+        net = DownSamplingBlock(num_classes, n)
+
+        output = net(inputs)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_UpSamplingBlock_skip(self):
+        num_classes = 16
+        n = 3
+        input_shape = (1,32,32,3)
+        skip_shape = (1,64,64,num_classes)
+        output_shape = skip_shape[:-1] + (num_classes,)
+
+        inputs = self.get_random_data(input_shape)
+        skips = self.get_random_data(skip_shape)
+        net = UpSamplingBlock(num_classes, n, is_skip=True, out_depthwise_ch=num_classes)
+
+        output = net(inputs, skips)
+        self.assertEqual(output_shape, output.shape) 
+
+    def test_UpSamplingBlock(self):
+        num_classes = 16
+        n = 3
+        input_shape = (1,32,32,3)
+        output_shape = (input_shape[0], input_shape[1]*2, input_shape[2]*2) + (num_classes,)
+
+        inputs = self.get_random_data(input_shape)
+        net = UpSamplingBlock(num_classes, n, is_skip=False, out_depthwise_ch=num_classes)
+
+        output = net(inputs, None)
+        self.assertEqual(output_shape, output.shape) 
+    
+    def test_UpSamplingBlock_padding(self):
+        num_classes = 4
+        n = 3
+
+        input_shape1 = (1,32,32,num_classes)
+        skip_shape1 = (1,64,65,num_classes)
+        output_shape1 = skip_shape1
+
+        input_shape2 = (1,31,31,num_classes)
+        skip_shape2 = (1,63,62,num_classes)
+        output_shape2 = skip_shape2
+
+        input_shape3 = (1,1,1,num_classes)
+        skip_shape3 = (1,2,2,num_classes)
+        output_shape3 = skip_shape3
+
+        net1 = UpSamplingBlock(num_classes, n, is_skip=True, out_depthwise_ch=num_classes)
+        net2 = UpSamplingBlock(num_classes, n, is_skip=True, out_depthwise_ch=num_classes)
+        net3 = UpSamplingBlock(num_classes, n, is_skip=True, out_depthwise_ch=num_classes)
+
+        inputs1 = self.get_random_data(input_shape1)
+        inputs2 = self.get_random_data(input_shape2)
+        inputs3 = self.get_random_data(input_shape3)
+
+        skips1 = self.get_random_data(skip_shape1)
+        skips2 = self.get_random_data(skip_shape2)
+        skips3 = self.get_random_data(skip_shape3)
+
+        output1 = net1(inputs1, skips1)
+        output2 = net2(inputs2, skips2)
+        output3 = net3(inputs3, skips3)
+
+        self.assertEqual(output_shape1, output1.shape)
+        self.assertEqual(output_shape2, output2.shape)
+        self.assertEqual(output_shape3, output3.shape)
+
+    def test_output_type_skip(self):
+        num_classes = 16
+        input_shape = (1,32,32,3)
+        output_shape = input_shape[:-1] + (num_classes,)
+        inputs = self.get_random_data(input_shape)
+        net = MobileUNet(num_classes)
+
+        output = net(inputs)
+
+        self.assertIsInstance(output, tf.Tensor)
+        self.assertIs(output.dtype, tf.float32)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_nomal_input_skip(self):
+        num_classes = 32
+        input_shape = (1,512,512,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_multi_batch_skip(self):
+        num_classes = 32
+        input_shape = (3,64,64,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_variable_input_skip(self):
+        num_classes = 32
+        input_shape = (1,71,61,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 32
+        input_shape = (1,117,41,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 32
+        input_shape = (1,37,129,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_small_input_skip(self):
+        num_classes = 32
+        input_shape = (1,15,15,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 32
+        input_shape = (1,15,512,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 32
+        input_shape = (1,512,15,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 32
+        input_shape = (1,1,1,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_variable_num_classes_skip(self):
+        num_classes = 16
+        input_shape = (1,512,512,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 7
+        input_shape = (1,512,512,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 2
+        input_shape = (1,512,512,3)
+        output, output_shape = self.network_skip(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_output_type(self):
+        num_classes = 16
+        input_shape = (1,32,32,3)
+        output_shape = input_shape[:-1] + (num_classes,)
+        inputs = self.get_random_data(input_shape)
+        net = MobileUNet(num_classes, "MobileUNet")
+
+        output = net(inputs)
+
+        self.assertIsInstance(output, tf.Tensor)
+        self.assertIs(output.dtype, tf.float32)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_nomal_input(self):
+        num_classes = 32
+        input_shape = (1,512,512,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_multi_batch(self):
+        num_classes = 32
+        input_shape = (3,64,64,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_variable_input(self):
+        num_classes = 32
+        input_shape = (1,71,61,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 32
+        input_shape = (1,117,41,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 32
+        input_shape = (1,37,129,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_small_input(self):
+        num_classes = 32
+        input_shape = (1,15,15,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 32
+        input_shape = (1,15,512,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 32
+        input_shape = (1,512,15,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 32
+        input_shape = (1,1,1,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+    def test_variable_num_classes(self):
+        num_classes = 16
+        input_shape = (1,512,512,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 7
+        input_shape = (1,512,512,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+        num_classes = 2
+        input_shape = (1,512,512,3)
+        output, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, output.shape)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/models/test_UNet.py
+++ b/tests/models/test_UNet.py
@@ -10,13 +10,13 @@ class TestStringMethods(unittest.TestCase):
 
     def network(self, input_shape, num_classes):
         output_shape = input_shape[:-1] + (num_classes,)
-        X = self.get_random_data(input_shape)
-        inputs = tf.placeholder(tf.float32, shape=input_shape)
-        net = build_unet(inputs, "UNet", num_classes)
+        input_data = self.get_random_data(input_shape)
+        net_input = tf.placeholder(tf.float32, shape=input_shape)
+        net = build_unet(net_input, "UNet", num_classes)
         
         sess = tf.Session()
         sess.run(tf.global_variables_initializer())
-        net = sess.run(net, feed_dict = {inputs: X})
+        net = sess.run(net, feed_dict = {net_input: input_data})
         return net, output_shape
     
     def test_ConvBlock(self):
@@ -24,13 +24,13 @@ class TestStringMethods(unittest.TestCase):
         input_shape = (1,32,32,4)
         output_shape = input_shape[:-1] + (num_classes,)
         
-        inputs = tf.placeholder(tf.float32, shape=input_shape)
-        net = ConvBlock(inputs, num_classes)
+        net_input = tf.placeholder(tf.float32, shape=input_shape)
+        net = ConvBlock(net_input, num_classes)
         
-        X = self.get_random_data(input_shape)
+        input_data = self.get_random_data(input_shape)
         sess = tf.Session()
         sess.run(tf.global_variables_initializer())
-        output = sess.run(net, feed_dict = {inputs: X})
+        output = sess.run(net, feed_dict = {net_input: input_data})
         self.assertEqual(output_shape, output.shape)
     
     def test_conv_transpose_block(self):
@@ -38,13 +38,13 @@ class TestStringMethods(unittest.TestCase):
         input_shape = (1,32,32,num_classes)
         output_shape = (1,64,64,num_classes)
         
-        inputs = tf.placeholder(tf.float32, shape=input_shape)
-        net = conv_transpose_block(inputs, num_classes)
+        net_input = tf.placeholder(tf.float32, shape=input_shape)
+        net = conv_transpose_block(net_input, num_classes)
         
-        X = self.get_random_data(input_shape)
+        input_data = self.get_random_data(input_shape)
         sess = tf.Session()
         sess.run(tf.global_variables_initializer())
-        output = sess.run(net, feed_dict = {inputs: X})
+        output = sess.run(net, feed_dict = {net_input: input_data})
         self.assertEqual(output_shape, output.shape)
 
     def test_conv_transpose_padding(self):
@@ -61,29 +61,30 @@ class TestStringMethods(unittest.TestCase):
         input_shape4 = (1,1,1,num_classes)
         output_shape4 = (1,2,2,num_classes)
         
-        inputs1 = tf.placeholder(tf.float32, shape=input_shape1)
-        inputs2 = tf.placeholder(tf.float32, shape=input_shape2)
-        inputs3 = tf.placeholder(tf.float32, shape=input_shape3)
-        inputs4 = tf.placeholder(tf.float32, shape=input_shape4)
+        net_input1 = tf.placeholder(tf.float32, shape=input_shape1)
+        net_input2 = tf.placeholder(tf.float32, shape=input_shape2)
+        net_input3 = tf.placeholder(tf.float32, shape=input_shape3)
+        net_input4 = tf.placeholder(tf.float32, shape=input_shape4)
         
-        net1 = conv_transpose_block(inputs1, num_classes,
+        net1 = conv_transpose_block(net_input1, num_classes,
                                     output_shape=output_shape1)
-        net2 = conv_transpose_block(inputs2, num_classes,
+        net2 = conv_transpose_block(net_input2, num_classes,
                                     output_shape=output_shape2)
-        net3 = conv_transpose_block(inputs3, num_classes,
+        net3 = conv_transpose_block(net_input3, num_classes,
                                     output_shape=output_shape3)
-        net4 = conv_transpose_block(inputs4, num_classes,
+        net4 = conv_transpose_block(net_input4, num_classes,
                                     output_shape=output_shape4)
         
-        X1 = self.get_random_data(input_shape1)
-        X2 = self.get_random_data(input_shape2)
-        X3 = self.get_random_data(input_shape3)
-        X4 = self.get_random_data(input_shape4)
+        input_data1 = self.get_random_data(input_shape1)
+        input_data2 = self.get_random_data(input_shape2)
+        input_data3 = self.get_random_data(input_shape3)
+        input_data4 = self.get_random_data(input_shape4)
         
         sess = tf.Session()
         sess.run(tf.global_variables_initializer())
         output_list = sess.run([net1, net2, net3, net4],
-            feed_dict = {inputs1: X1,inputs2: X2, inputs3: X3,inputs4: X4})
+            feed_dict = {net_input1: input_data1, net_input2: input_data2,
+                         net_input3: input_data3, net_input4: input_data4})
        
         self.assertEqual(output_shape1, output_list[0].shape)
         self.assertEqual(output_shape2, output_list[1].shape)
@@ -96,27 +97,27 @@ class TestStringMethods(unittest.TestCase):
         output_shape = (1,95,121,num_classes)
         strides = [3, 4]
         
-        inputs = tf.placeholder(tf.float32, shape=input_shape)
-        net = conv_transpose_block(inputs, num_classes, strides=strides,
+        net_input = tf.placeholder(tf.float32, shape=input_shape)
+        net = conv_transpose_block(net_input, num_classes, strides=strides,
             output_shape=output_shape)
         
-        X = self.get_random_data(input_shape)
+        input_data = self.get_random_data(input_shape)
         sess = tf.Session()
         sess.run(tf.global_variables_initializer())
-        output = sess.run(net, feed_dict = {inputs: X})
+        output = sess.run(net, feed_dict = {net_input: input_data})
         self.assertEqual(output_shape, output.shape)
     
     def test_output_type(self):
         num_classes = 16
         input_shape = (1,32,32,3)
         output_shape = input_shape[:-1] + (num_classes,)
-        X = self.get_random_data(input_shape)
-        inputs = tf.placeholder(tf.float32, shape=input_shape)
-        net = build_unet(inputs, "UNet", num_classes)
+        input_data = self.get_random_data(input_shape)
+        net_input = tf.placeholder(tf.float32, shape=input_shape)
+        net = build_unet(net_input, "UNet", num_classes)
         
         sess = tf.Session()
         sess.run(tf.global_variables_initializer())
-        output = sess.run(net, feed_dict = {inputs: X})
+        output = sess.run(net, feed_dict = {net_input: input_data})
         
         self.assertIsInstance(net, tf.Tensor)
         self.assertIsInstance(output, np.ndarray)

--- a/tests/models/test_UNet.py
+++ b/tests/models/test_UNet.py
@@ -1,0 +1,193 @@
+import unittest
+import numpy as np
+import tensorflow as tf
+from models.UNet import build_unet, ConvBlock, conv_transpose_block
+
+class TestStringMethods(unittest.TestCase):
+
+    def get_random_data(self, shape):
+        return np.random.rand(*shape)
+
+    def network(self, input_shape, num_classes):
+        output_shape = input_shape[:-1] + (num_classes,)
+        X = self.get_random_data(input_shape)
+        inputs = tf.placeholder(tf.float32, shape=input_shape)
+        net = build_unet(inputs, "UNet", num_classes)
+        
+        sess = tf.Session()
+        sess.run(tf.global_variables_initializer())
+        net = sess.run(net, feed_dict = {inputs: X})
+        return net, output_shape
+    
+    def test_ConvBlock(self):
+        num_classes = 16
+        input_shape = (1,32,32,4)
+        output_shape = input_shape[:-1] + (num_classes,)
+        
+        inputs = tf.placeholder(tf.float32, shape=input_shape)
+        net = ConvBlock(inputs, num_classes)
+        
+        X = self.get_random_data(input_shape)
+        sess = tf.Session()
+        sess.run(tf.global_variables_initializer())
+        output = sess.run(net, feed_dict = {inputs: X})
+        self.assertEqual(output_shape, output.shape)
+    
+    def test_conv_transpose_block(self):
+        num_classes = 4
+        input_shape = (1,32,32,num_classes)
+        output_shape = (1,64,64,num_classes)
+        
+        inputs = tf.placeholder(tf.float32, shape=input_shape)
+        net = conv_transpose_block(inputs, num_classes)
+        
+        X = self.get_random_data(input_shape)
+        sess = tf.Session()
+        sess.run(tf.global_variables_initializer())
+        output = sess.run(net, feed_dict = {inputs: X})
+        self.assertEqual(output_shape, output.shape)
+
+    def test_conv_transpose_padding(self):
+        num_classes = 4
+        input_shape1 = (1,32,32,num_classes)
+        output_shape1 = (1,63,64,num_classes)
+
+        input_shape2 = (1,31,31,num_classes)
+        output_shape2 = (1,61,62,num_classes)
+
+        input_shape3 = (1,1,1,num_classes)
+        output_shape3 = (1,1,1,num_classes)
+
+        input_shape4 = (1,1,1,num_classes)
+        output_shape4 = (1,2,2,num_classes)
+        
+        inputs1 = tf.placeholder(tf.float32, shape=input_shape1)
+        inputs2 = tf.placeholder(tf.float32, shape=input_shape2)
+        inputs3 = tf.placeholder(tf.float32, shape=input_shape3)
+        inputs4 = tf.placeholder(tf.float32, shape=input_shape4)
+        
+        net1 = conv_transpose_block(inputs1, num_classes,
+                                    output_shape=output_shape1)
+        net2 = conv_transpose_block(inputs2, num_classes,
+                                    output_shape=output_shape2)
+        net3 = conv_transpose_block(inputs3, num_classes,
+                                    output_shape=output_shape3)
+        net4 = conv_transpose_block(inputs4, num_classes,
+                                    output_shape=output_shape4)
+        
+        X1 = self.get_random_data(input_shape1)
+        X2 = self.get_random_data(input_shape2)
+        X3 = self.get_random_data(input_shape3)
+        X4 = self.get_random_data(input_shape4)
+        
+        sess = tf.Session()
+        sess.run(tf.global_variables_initializer())
+        output_list = sess.run([net1, net2, net3, net4],
+            feed_dict = {inputs1: X1,inputs2: X2, inputs3: X3,inputs4: X4})
+       
+        self.assertEqual(output_shape1, output_list[0].shape)
+        self.assertEqual(output_shape2, output_list[1].shape)
+        self.assertEqual(output_shape3, output_list[2].shape)
+        self.assertEqual(output_shape4, output_list[3].shape)
+
+    def test_conv_transpose_strides(self):
+        num_classes = 4
+        input_shape = (1,32,31,num_classes)
+        output_shape = (1,95,121,num_classes)
+        strides = [3, 4]
+        
+        inputs = tf.placeholder(tf.float32, shape=input_shape)
+        net = conv_transpose_block(inputs, num_classes, strides=strides,
+            output_shape=output_shape)
+        
+        X = self.get_random_data(input_shape)
+        sess = tf.Session()
+        sess.run(tf.global_variables_initializer())
+        output = sess.run(net, feed_dict = {inputs: X})
+        self.assertEqual(output_shape, output.shape)
+    
+    def test_output_type(self):
+        num_classes = 16
+        input_shape = (1,32,32,3)
+        output_shape = input_shape[:-1] + (num_classes,)
+        X = self.get_random_data(input_shape)
+        inputs = tf.placeholder(tf.float32, shape=input_shape)
+        net = build_unet(inputs, "UNet", num_classes)
+        
+        sess = tf.Session()
+        sess.run(tf.global_variables_initializer())
+        output = sess.run(net, feed_dict = {inputs: X})
+        
+        self.assertIsInstance(net, tf.Tensor)
+        self.assertIsInstance(output, np.ndarray)
+        self.assertIs(net.dtype, tf.float32)
+        self.assertIs(output.dtype, np.dtype('float32'))
+        
+    def test_nomal_input(self):
+        num_classes = 32
+        input_shape = (1,512,512,3)
+        net, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, net.shape)
+
+    def test_multi_batch(self):
+        num_classes = 32
+        input_shape = (3,64,64,3)
+        net, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, net.shape)
+        
+    def test_variable_input(self):
+        num_classes = 32
+        input_shape = (1,71,61,3)
+        net, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, net.shape)
+
+        num_classes = 32
+        input_shape = (1,117,41,3)
+        net, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, net.shape)
+
+        num_classes = 32
+        input_shape = (1,37,129,3)
+        net, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, net.shape)
+        
+    def test_small_input(self):
+        num_classes = 32
+        input_shape = (1,15,15,3)
+        net, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, net.shape)
+
+        num_classes = 32
+        input_shape = (1,15,512,3)
+        net, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, net.shape)
+
+        num_classes = 32
+        input_shape = (1,512,15,3)
+        net, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, net.shape)
+
+        num_classes = 32
+        input_shape = (1,1,1,3)
+        net, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, net.shape)
+        
+    def test_variable_num_classes(self):
+        num_classes = 16
+        input_shape = (1,512,512,3)
+        net, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, net.shape)
+
+        num_classes = 7
+        input_shape = (1,512,512,3)
+        net, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, net.shape)
+
+        num_classes = 2
+        input_shape = (1,512,512,3)
+        net, output_shape = self.network(input_shape, num_classes)
+        self.assertEqual(output_shape, net.shape)
+
+    
+if __name__ == '__main__':
+    unittest.main()

--- a/train.py
+++ b/train.py
@@ -89,7 +89,7 @@ sess=tf.Session(config=config)
 
 
 # Compute your softmax cross entropy loss
-net_input = tf.placeholder(tf.float32,shape=[None,None,None,3])
+net_input = tf.placeholder(tf.float32,shape=[None,args.crop_height,args.crop_width,3])
 net_output = tf.placeholder(tf.float32,shape=[None,None,None,num_classes])
 
 network, init_fn = model_builder.build_model(model_name=args.model, frontend=args.frontend, net_input=net_input, num_classes=num_classes, crop_width=args.crop_width, crop_height=args.crop_height, is_training=True)


### PR DESCRIPTION
#16 
Fix input size problem in U-Net using pad.
And change padding according to the strides to make it easier to modify the strides.
But other models still need to fix problem.